### PR TITLE
fix: sanitize MCP tool arguments

### DIFF
--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -93,6 +93,31 @@ function createAbortHandler({ userId, serverName, toolName, flowManager }) {
 }
 
 /**
+ * Parses stringified JSON arguments, removing escape characters until a non-string is returned.
+ * @param {object|string} args
+ * @param {{userId: string, serverName: string, toolName: string, toolKey: string}} meta
+ * @returns {object}
+ */
+function parseJSONArguments(args, { userId, serverName, toolName, toolKey }) {
+  if (typeof args !== 'string') {
+    return args;
+  }
+  try {
+    let parsed = args;
+    while (typeof parsed === 'string') {
+      parsed = JSON.parse(parsed);
+    }
+    return parsed;
+  } catch (err) {
+    logger.error(
+      `[MCP][User: ${userId}][${serverName}][${toolName}] Invalid JSON arguments provided:`,
+      err,
+    );
+    throw new Error(`Invalid JSON provided for "${toolKey}" tool`);
+  }
+}
+
+/**
  * Creates a general tool for an entire action set.
  *
  * @param {Object} params - The parameters for loading action sets.
@@ -172,18 +197,12 @@ async function createMCPTool({ req, res, toolKey, provider: _provider }) {
         config?.configurable?.userMCPAuthMap?.[`${Constants.mcp_prefix}${serverName}`];
 
       // Intercept JSON arguments and ensure they are valid before calling the MCP tool
-      if (typeof toolArguments === 'string') {
-        try {
-          const parsed = JSON.parse(toolArguments);
-          toolArguments = typeof parsed === 'string' ? JSON.parse(parsed) : parsed;
-        } catch (err) {
-          logger.error(
-            `[MCP][User: ${userId}][${serverName}][${toolName}] Invalid JSON arguments provided:`,
-            err,
-          );
-          throw new Error(`Invalid JSON provided for "${toolKey}" tool`);
-        }
-      }
+      toolArguments = parseJSONArguments(toolArguments, {
+        userId,
+        serverName,
+        toolName,
+        toolKey,
+      });
 
       const result = await mcpManager.callTool({
         serverName,

--- a/api/server/services/MCP.js
+++ b/api/server/services/MCP.js
@@ -171,6 +171,20 @@ async function createMCPTool({ req, res, toolKey, provider: _provider }) {
       const customUserVars =
         config?.configurable?.userMCPAuthMap?.[`${Constants.mcp_prefix}${serverName}`];
 
+      // Intercept JSON arguments and ensure they are valid before calling the MCP tool
+      if (typeof toolArguments === 'string') {
+        try {
+          const parsed = JSON.parse(toolArguments);
+          toolArguments = typeof parsed === 'string' ? JSON.parse(parsed) : parsed;
+        } catch (err) {
+          logger.error(
+            `[MCP][User: ${userId}][${serverName}][${toolName}] Invalid JSON arguments provided:`,
+            err,
+          );
+          throw new Error(`Invalid JSON provided for "${toolKey}" tool`);
+        }
+      }
+
       const result = await mcpManager.callTool({
         serverName,
         toolName,

--- a/api/server/services/MCP.toolArgs.spec.js
+++ b/api/server/services/MCP.toolArgs.spec.js
@@ -101,5 +101,39 @@ describe('createMCPTool argument parsing', () => {
     expect(callTool).toHaveBeenCalled();
     expect(callTool.mock.calls[0][0].toolArguments).toEqual({ foo: 'bar' });
   });
+
+  it('handles nested stringified JSON arguments', async () => {
+    const req = { user: { id: 'user-1' } };
+    const res = {};
+    const tool = await createMCPTool({
+      req,
+      res,
+      toolKey: 'tool::server',
+      provider: 'openai',
+    });
+
+    const config = { metadata: { thread_id: 't1', run_id: 'r1' } };
+    await tool._call('"{\\"foo\\":\\"bar\\"}"', config);
+
+    const callTool = getMCPManager().callTool;
+    expect(callTool).toHaveBeenCalled();
+    expect(callTool.mock.calls[0][0].toolArguments).toEqual({ foo: 'bar' });
+  });
+
+  it('throws an error when JSON arguments are invalid', async () => {
+    const req = { user: { id: 'user-1' } };
+    const res = {};
+    const tool = await createMCPTool({
+      req,
+      res,
+      toolKey: 'tool::server',
+      provider: 'openai',
+    });
+
+    const config = { metadata: { thread_id: 't1', run_id: 'r1' } };
+    await expect(tool._call('{"foo":"bar"', config)).rejects.toThrow(
+      'Invalid JSON provided for "tool::server" tool',
+    );
+  });
 });
 

--- a/api/server/services/MCP.toolArgs.spec.js
+++ b/api/server/services/MCP.toolArgs.spec.js
@@ -1,0 +1,105 @@
+jest.mock(
+  '@librechat/data-schemas',
+  () => ({
+    logger: {
+      debug: jest.fn(),
+      error: jest.fn(),
+      info: jest.fn(),
+    },
+  }),
+  { virtual: true },
+);
+
+jest.mock(
+  '@librechat/api',
+  () => ({
+    sendEvent: jest.fn(),
+    MCPOAuthHandler: { generateFlowId: jest.fn() },
+    normalizeServerName: jest.fn((name) => name),
+    convertWithResolvedRefs: jest.fn(() => null),
+  }),
+  { virtual: true },
+);
+
+jest.mock(
+  '@librechat/agents',
+  () => ({
+    Constants: { CONTENT_AND_ARTIFACT: 'artifact' },
+    Providers: { VERTEXAI: 'vertexai', GOOGLE: 'google' },
+    GraphEvents: { ON_RUN_STEP_DELTA: 'on_run_step_delta' },
+  }),
+  { virtual: true },
+);
+
+jest.mock(
+  'librechat-data-provider',
+  () => ({
+    Time: { TWO_MINUTES: 120000 },
+    CacheKeys: { FLOWS: 'flows' },
+    StepTypes: { TOOL_CALLS: 'tool_calls' },
+    Constants: { mcp_delimiter: '::', mcp_prefix: 'mcp_' },
+    ContentTypes: { TEXT: 'text' },
+    isAssistantsEndpoint: () => false,
+  }),
+  { virtual: true },
+);
+
+jest.mock('~/config', () => ({
+  getMCPManager: jest.fn(),
+  getFlowStateManager: jest.fn(),
+}));
+
+jest.mock('~/cache', () => ({
+  getLogStores: jest.fn(() => ({})),
+}));
+
+jest.mock('./Config', () => ({
+  getCachedTools: jest.fn(),
+}));
+
+jest.mock('~/models', () => ({
+  findToken: jest.fn(),
+  createToken: jest.fn(),
+  updateToken: jest.fn(),
+}));
+
+jest.mock('@langchain/core/tools', () => ({
+  tool: (callFn) => ({ _call: callFn, mcp: true }),
+}));
+
+const { createMCPTool } = require('./MCP');
+
+const { getMCPManager, getFlowStateManager } = require('~/config');
+const { getCachedTools } = require('./Config');
+
+describe('createMCPTool argument parsing', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    getMCPManager.mockReturnValue({ callTool: jest.fn(async (opts) => opts) });
+    getFlowStateManager.mockReturnValue({});
+    getCachedTools.mockResolvedValue({
+      'tool::server': {
+        function: { description: '', parameters: {} },
+      },
+    });
+  });
+
+  it('parses stringified JSON arguments before calling mcp tool', async () => {
+    const req = { user: { id: 'user-1' } };
+    const res = {};
+    const tool = await createMCPTool({
+      req,
+      res,
+      toolKey: 'tool::server',
+      provider: 'openai',
+    });
+
+    const config = { metadata: { thread_id: 't1', run_id: 'r1' } };
+    await tool._call('{"foo":"bar"}', config);
+
+    const callTool = getMCPManager().callTool;
+    expect(callTool).toHaveBeenCalled();
+    expect(callTool.mock.calls[0][0].toolArguments).toEqual({ foo: 'bar' });
+  });
+});
+


### PR DESCRIPTION
## Summary
- validate and parse JSON arguments before calling MCP tools
- add regression test for MCP JSON argument parsing

## Testing
- `npm run test:api -- api/server/services/MCP.toolArgs.spec.js`
- `npm run test:api` *(fails: Cannot find module '@librechat/api' ...)*

------
https://chatgpt.com/codex/tasks/task_e_689225731d748333a73741d04e755f26